### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ server.register([
         'author': {
           model: 'Author',          // Model name in registry
           basePath: '/authors',
-          specialColumn: {          // Optional info about special columns
+          specialColumns: {          // Optional info about special columns
             updated: 'updated_at',  // Column set to NOW() on PATCH etc.
             meta: ['created_at', 'updated_at'], // Columns included in "meta"
                                                 // instead of "attributes"


### PR DESCRIPTION
Fix important typo in README in order for `specialColumns` features to work